### PR TITLE
Small diddies

### DIFF
--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -17,7 +17,9 @@
   
   <% if @articles %>
   <div class="meta">
+    <% if Spree::Config[:disqus_id] %>
     <p class="comments"><a href="<%= article_url article %>#respond" title="Comment on <%= article.title %>">Comments &#187;</a></p>
+    <% end %>
     <p class="time">Posted @ <%= format_time article.date %></p>
     <br class="clear" />
   </div>

--- a/lib/tasks/blog.rake
+++ b/lib/tasks/blog.rake
@@ -9,7 +9,7 @@ namespace :blog do
     article << "\n"
     article << "Lorem ipsum dolor sit amet...\n\n"
 
-    path = "#{RAILS_ROOT}/content/articles/#{Time.now.strftime("%Y-%m-%d")}#{'-' + slug if slug}.txt"
+    path = "#{RAILS_ROOT}/content/article/#{Time.now.strftime("%Y-%m-%d")}#{'-' + slug if slug}.txt"
 
     unless File.exist? path
       File.open(path, "w") do |file|

--- a/spree_simple_blog.gemspec
+++ b/spree_simple_blog.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true
 
-  s.add_dependency('spree_core', '0.30.0.beta1')
+  s.add_dependency('spree_core', '0.30.1')
   s.add_dependency('rdiscount', '1.5.5')
 
 end


### PR DESCRIPTION
fixed spree to 0.30.1
content dir in the rake task was wrong
hides comments when they are not configured

I'll go on to change it to "news" which I find more appropriate than blog in a shop.
And also to make it possible to associate a product.
But great starting point and I like the file idea.
So thanks

Torsten
