### PR TITLE
Remove unnecessary route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Spree::Core::Engine.routes.prepend do
 
   match '/blog',                              :to => 'articles#index',   :as => 'blog_articles'
-  match '/blog.:format',                      :to => 'articles#index',   :as => 'blog_articles'
   match '/blog/tag/:tag',                     :to => 'articles#tag',     :as => 'blog_tag'
   match '/blog/page/:page',                   :to => 'articles#index',   :as => 'blog_articles_page'
   match '/blog/:year/:month',                 :to => 'articles#archive', :as => 'blog_articles_archive'


### PR DESCRIPTION
Rails now automatically adds (.:format) on the end of routes.
